### PR TITLE
Add viewport meta to head partial

### DIFF
--- a/views/partials/head.ejs
+++ b/views/partials/head.ejs
@@ -1,4 +1,5 @@
 <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=REM:ital,wght@0,200;0,400;0,600;0,800;1,200&display=swap" rel="stylesheet">


### PR DESCRIPTION
This PR gives a quick fix for to the head partial view meta tags and page showing 1080 px wide on mobile view.